### PR TITLE
Swap USER directive for gosu for runtime permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN chmod +x /token.sh /entrypoint.sh \
     && usermod -aG sudo runner \
     && usermod -aG docker runner \
     && chown runner /_work/ /opt/hostedtoolcache/
-USER runner
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["./bin/Runner.Listener", "run", "--startuptype", "service"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,7 @@ RUN chmod +x /actions-runner/install_actions.sh \
   && rm /actions-runner/install_actions.sh
 
 COPY token.sh entrypoint.sh /
-RUN chmod +x /token.sh /entrypoint.sh \
-    && groupadd -g 121 runner \
-    && useradd -mr -d /home/runner -u 1001 -g 121 runner \
-    && usermod -aG sudo runner \
-    && usermod -aG docker runner \
-    && chown runner /_work/ /opt/hostedtoolcache/
+RUN chmod +x /token.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["./bin/Runner.Listener", "run", "--startuptype", "service"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -67,4 +67,8 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && ( [[ $(lsb_release --codename | cut -f2) == "focal" || $(lsb_release --codename | cut -f2) == "jammy" ||  $(lsb_release --codename | cut -f2) == "sid" ||  $(lsb_release --codename | cut -f2) == "bullseye" ]] && apt-get install -y --no-install-recommends podman buildah skopeo || : ) \
   && ( [[ $(lsb_release --codename | cut -f2) == "jammy" ]] && echo "Ubuntu Jammy is marked as beta. Please see https://github.com/actions/virtual-environments/issues/5490" || : ) \
   && rm -rf /var/lib/apt/lists/* \
-  && rm -rf /tmp/*
+  && rm -rf /tmp/* \
+  && groupadd -g 121 runner \
+  && useradd -mr -d /home/runner -u 1001 -g 121 runner \
+  && usermod -aG sudo runner \
+  && usermod -aG docker runner

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -44,6 +44,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
     dumb-init \
     nodejs \
     rsync \
+    gosu \
   && sed -e 's/Defaults.*env_reset/Defaults env_keep = "HTTP_PROXY HTTPS_PROXY NO_PROXY FTP_PROXY http_proxy https_proxy no_proxy ftp_proxy"/' -i /etc/sudoers \
   && echo deb http://ppa.launchpad.net/git-core/ppa/ubuntu $([[ $(grep -E '^ID=' /etc/os-release | sed 's/.*=//g') == "ubuntu" ]] && (grep VERSION_CODENAME /etc/os-release | sed 's/.*=//g') || echo bionic) main>/etc/apt/sources.list.d/git-core.list \
   && apt-get update \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -71,4 +71,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && groupadd -g 121 runner \
   && useradd -mr -d /home/runner -u 1001 -g 121 runner \
   && usermod -aG sudo runner \
-  && usermod -aG docker runner
+  && usermod -aG docker runner \
+  && mkdir -p /_work/ /opt/hostedtoolcache/ \
+  && chown runner /_work/ /opt/hostedtoolcache/
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,6 +91,9 @@ configure_runner() {
       --replace \
       ${_EPHEMERAL} \
       ${_AUTO_UPDATE}
+
+  [[ ! -d "${_RUNNER_WORKDIR}" ]] && mkdir "${_RUNNER_WORKDIR}"
+  /usr/bin/chown -R runner ${_RUNNER_WORKDIR} /opt/hostedtoolcache/ /actions-runner
 }
 
 
@@ -124,5 +127,5 @@ if [[ ${_DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
   trap deregister_runner SIGINT SIGQUIT SIGTERM INT TERM QUIT
 fi
 
-# Container's command (CMD) execution
-"$@"
+# Container's command (CMD) execution as runner user
+/usr/sbin/gosu runner "$@"


### PR DESCRIPTION
This allows us to fix runtime permissions by using `gosu` vs the `USER` directive

Now we can fix the dynamic `RUNNER_WORKDIR` directory if provided at runtime and run as non-root at the final command.

Also fixes a foot gun where `/actions-runner` is created at `config.sh` and would not have been able to be created as the user